### PR TITLE
dos2unix issue fixed

### DIFF
--- a/bash-ini-parser
+++ b/bash-ini-parser
@@ -21,6 +21,7 @@ function cfg_parser {
       shopt -s extglob
    fi
    ini="$(<$1)"                 # read the file
+   ini=${ini//$'\r'/}           # remove linefeed i.e dos2unix
    ini="${ini//[/\\[}"          # escape [
    debug
    ini="${ini//]/\\]}"          # escape ]


### PR DESCRIPTION
By default this ini parser produce errors while parsing Windows / DOS based files, this fix will resolve that problem