### PR TITLE
length=${#FUNCNAME/#cfg_section_;[*]}: bad substitution - solution

### DIFF
--- a/bash-ini-parser
+++ b/bash-ini-parser
@@ -92,6 +92,7 @@ function cfg_writer {
       item="$(declare -f ${f})"
       item="${item##*\{}" # remove function definition
       item="${item##*FUNCNAME*$PREFIX\};}" # remove clear section
+      item="${item/FUNCNAME\/#$PREFIX;}" # remove line
       item="${item/\}}"  # remove function close
       item="${item%)*}" # remove everything after parenthesis
       item="${item});" # add close parenthesis


### PR DESCRIPTION
Solution for #9 