### PR TITLE
Set back the old "IFS" in "cfg_parser" function

### DIFF
--- a/bash-ini-parser
+++ b/bash-ini-parser
@@ -29,6 +29,7 @@ function cfg_parser {
    debug "escaped ["
    ini="${ini//]/\\]}"
    debug "escaped ]"
+   OLDIFS="$IFS"
    IFS=$'\n' && ini=( ${ini} )  # convert to line-array
    debug
    ini=( ${ini[*]/#*([[:space:]]);*/} )
@@ -77,6 +78,7 @@ function cfg_parser {
    then
       shopt -u extglob
    fi
+   IFS="$OLDIFS"
    return $EVAL_STATUS
 }
 


### PR DESCRIPTION
The "cfg_parser" function set the "IFS" but it doesn't set back the "old" one. If you source and use the parser then it is possible that your IFS will be changed on caller side.

fixes #31 