### PR TITLE
Bash Set

### DIFF
--- a/bash-ini-parser
+++ b/bash-ini-parser
@@ -2,6 +2,8 @@
 # based on http://theoldschooldevops.com/2008/02/09/bash-ini-parser/
 #
 
+set +eu
+
 PREFIX="cfg_section_"
 
 function debug {


### PR DESCRIPTION
Fix for use with "set -Eeuo pipefail", not working if is set "-eu" on main script