### PR TITLE
Removing double quotes around arrays to keep them as array.

### DIFF
--- a/bash-ini-parser
+++ b/bash-ini-parser
@@ -132,7 +132,7 @@ function cfg_writer {
             echo $var=\"${!var}\" #output var
          else
             echo ";$var is an array" # add comment denoting var is an array
-            eval 'echo $var=\"${'$var'[*]}\"' # output array var
+            eval 'echo $var=${'$var'[*]}' # output array var
          fi
       done
    done


### PR DESCRIPTION
Detecting if a variable is a multiword value or an array is based on the presence of double quotes around the value.
By adding the double quotes around the array values in `cfg_writer` the resulting file loses the notion that the variable should be an array and instead become a multiword value.