### PR TITLE
Fix the "eval" error due to empty lines in the INI file

### DIFF
--- a/bash-ini-parser
+++ b/bash-ini-parser
@@ -22,8 +22,9 @@ function cfg_parser {
    then
       shopt -s extglob
    fi
-   ini="$(<$1)"                 # read the file
-   ini=${ini//$'\r'/}           # remove linefeed i.e dos2unix
+   ini="$(<$1)"                     # read the file
+   ini=${ini//$'\r'/}               # remove linefeed i.e dos2unix
+   ini=$(echo "${ini}" | awk NF)    # Remove the empty lines.
 
    ini="${ini//[/\\[}"
    debug "escaped ["


### PR DESCRIPTION
**Why:**

If there is empty trailing line in the INI file you can get the following error:

```
eval: line 64: syntax error near unexpected token `}'
```

**Solution:**
 - My change removes the empty lines from INI file.

**My test `INI` file:**

```
# This config file is used for testing

[SERVER]
user            = user
pws             = password

```

**My test code:**

```
#!/bin/bash -e

SCRIPT_FULL_PATH=$(readlink -f "${BASH_SOURCE[0]:-${0}}")
SCRIPT_DIR_PATH="${SCRIPT_FULL_PATH%/*}"

source "${SCRIPT_DIR_PATH}/bash_ini_parser.sh"

cfg_parser "${SCRIPT_DIR_PATH}/configs/servers.ini"

echo "DONE"
```

**Test run without my change (With an extra echo):**

```
 >>> ./test.sh 

}
cfg_section_SERVER () {
cfg_unset SERVER
user=( user )
pws=( password )
}
/home/milanbalazs/scripts/bash_ini_parser.sh: eval: line 65: syntax error near unexpected token `}'
```

**Test run with my change (With an extra echo):**

```
>>> ./test.sh 
cfg_section_SERVER () {
cfg_unset SERVER
user=( user )
pws=( password )
}
DONE
```

**Conclusion:**
 - As you can see above my change solves the wrong and unnecessary `}` character beginning of the structure of `eval` function.